### PR TITLE
Allow choice of underline style

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There is no need to call setup if you are ok with the defaults (light theme).
 
 ```lua
 require("leaf").setup({
-    undercurl = true,
+    underlineStyle = "undercurl",
     commentStyle = "italic",
     functionStyle = "NONE",
     keywordStyle = "italic",

--- a/lua/leaf/hlgroups.lua
+++ b/lua/leaf/hlgroups.lua
@@ -57,19 +57,19 @@ function M.setup(colors, config)
         IncSearch = { fg = colors.fg_colored_bg, bg = colors.yellow_hard, style = "NONE" },
         SpecialKey = { link = "NonText" },
         SpellBad = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.red_hard,
         },
         SpellCap = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.yellow_hard,
         },
         SpellLocal = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.yellow_hard,
         },
         SpellRare = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.yellow_hard,
         },
         StatusLine = { fg = colors.fg_dim, bg = colors.bg_dimmer, style = "NONE" },
@@ -173,19 +173,19 @@ function M.setup(colors, config)
         DiagnosticVirtualTextHint = { link = "DiagnosticHint" },
 
         DiagnosticUnderlineError = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.red_hard,
         },
         DiagnosticUnderlineWarn = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.yellow_hard,
         },
         DiagnosticUnderlineInfo = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.blue_hard,
         },
         DiagnosticUnderlineHint = {
-            style = config.undercurl and "undercurl" or "NONE",
+            style = config.underlineStyle,
             guisp = colors.teal_hard,
         },
 

--- a/lua/leaf/init.lua
+++ b/lua/leaf/init.lua
@@ -18,7 +18,7 @@ end
 
 --- default config
 M.config = {
-    undercurl = true,
+    underlineStyle = "undercurl",
     commentStyle = "italic",
     functionStyle = "NONE",
     keywordStyle = "italic",


### PR DESCRIPTION
Replace `undercurl` boolean with `underlineStyle` string so any underline style can be chosen (eg, underline, undercurl, underdash, etc).